### PR TITLE
Use the gradle shadow plugin to relocate javax.servlet classes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
+apply from: file('cursedmeizu.gradle')
 
 android {
     compileSdkVersion 28
@@ -33,6 +34,5 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "androidx.test:core:1.2.0"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation "com.github.tomakehurst:wiremock-standalone:2.23.2"
     androidTestImplementation "androidx.test.ext:junit:1.1.1"
 }

--- a/app/cursedmeizu.gradle
+++ b/app/cursedmeizu.gradle
@@ -1,0 +1,34 @@
+// Both wiremock and meizu embed javax.servlet classes. 
+// They don't embed the same version of these classes, which causes instrumentation
+// tests to fail when run on a meizu device.
+// The workaround here is to relocate the javax.servlet classes embedded by wiremock,
+// for androidTest tests.
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
+    }
+}
+apply plugin: com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+android {
+    dependencies {
+        shadow "com.github.tomakehurst:wiremock-standalone:2.23.2"
+        androidTestImplementation files("$buildDir/libs/shadow.jar")
+    }
+}
+
+tasks.configureEach { theTask ->
+    def taskName = theTask.name.toString()
+    if (taskName =~ /generate.*Sources/) {
+        theTask.dependsOn tasks.named("shadowJar")
+    }
+}
+
+tasks.register("shadowJar", ShadowJar) {
+    baseName = 'shadow'
+    configurations = [project.configurations.shadow]
+    relocate ('javax.servlet', 'com.example.wiremockexample.javax.servlet'){}
+}


### PR DESCRIPTION
This way there will be no conflict between the classes wiremock depends on and whatever Meizu has decided to embed in the Android system classpath.